### PR TITLE
add announcement api logic into announcement screen implementation

### DIFF
--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
@@ -59,6 +59,11 @@ open class KtorDroidKaigiApi constructor(
             getSessions()
         }
 
+    override fun getAnnouncementsAsync(lang: LangParameter): Deferred<AnnouncementListResponse> =
+        GlobalScope.async(requireNotNull(coroutineDispatcherForCallback)) {
+            getAnnouncements(lang)
+        }
+
     override suspend fun getAnnouncements(lang: LangParameter): AnnouncementListResponse {
         val rawResponse = httpClient.get<String> {
             url("$apiEndpoint/announcements?language=${lang.name}")

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/DroidKaigiApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/DroidKaigiApi.kt
@@ -15,6 +15,8 @@ interface DroidKaigiApi {
 
     fun getSessionsAsync(): Deferred<Response>
 
+    fun getAnnouncementsAsync(lang: LangParameter): Deferred<AnnouncementListResponse>
+
     suspend fun getSponsors(): SponsorResponse
 
     suspend fun getAnnouncements(lang: LangParameter): AnnouncementListResponse

--- a/frontend/ios/DroidKaigi 2019.xcodeproj/project.pbxproj
+++ b/frontend/ios/DroidKaigi 2019.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		6F7639172205614B0028EA21 /* Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7639162205614B0028EA21 /* Announcement.swift */; };
 		6F76391922056A860028EA21 /* AnnouncementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F76391822056A860028EA21 /* AnnouncementTableViewCell.swift */; };
 		6F76391B220577E10028EA21 /* AnnouncementDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F76391A220577E10028EA21 /* AnnouncementDataSource.swift */; };
+		6F76391F2206CF4A0028EA21 /* AnnouncementRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F76391E2206CF4A0028EA21 /* AnnouncementRepository.swift */; };
+		6F7639212206CFBE0028EA21 /* AnnouncementsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7639202206CFBE0028EA21 /* AnnouncementsViewModel.swift */; };
+		6F76392322072CE20028EA21 /* ApiHandleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F76392222072CE20028EA21 /* ApiHandleRepository.swift */; };
 		7B76F7A821FB45D2008A059B /* KotlinxDeferred+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B76F7A721FB45D2008A059B /* KotlinxDeferred+Extension.swift */; };
 		B977F3002202030B0048A02E /* FloorMap.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B977F2FF2202030B0048A02E /* FloorMap.storyboard */; };
 		B977F302220203170048A02E /* FloorMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B977F301220203170048A02E /* FloorMapViewController.swift */; };
@@ -167,6 +170,9 @@
 		6F7639162205614B0028EA21 /* Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcement.swift; sourceTree = "<group>"; };
 		6F76391822056A860028EA21 /* AnnouncementTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementTableViewCell.swift; sourceTree = "<group>"; };
 		6F76391A220577E10028EA21 /* AnnouncementDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementDataSource.swift; sourceTree = "<group>"; };
+		6F76391E2206CF4A0028EA21 /* AnnouncementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementRepository.swift; sourceTree = "<group>"; };
+		6F7639202206CFBE0028EA21 /* AnnouncementsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViewModel.swift; sourceTree = "<group>"; };
+		6F76392222072CE20028EA21 /* ApiHandleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiHandleRepository.swift; sourceTree = "<group>"; };
 		724135790B4D380473272A9A /* Pods-DroidKaigi 2019UITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DroidKaigi 2019UITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DroidKaigi 2019UITests/Pods-DroidKaigi 2019UITests.release.xcconfig"; sourceTree = "<group>"; };
 		7B76F7A721FB45D2008A059B /* KotlinxDeferred+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "KotlinxDeferred+Extension.swift"; sourceTree = "<group>"; };
 		8A9EFD2BFF415746908BCDDF /* Pods-DroidKaigi 2019.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DroidKaigi 2019.release.xcconfig"; path = "Pods/Target Support Files/Pods-DroidKaigi 2019/Pods-DroidKaigi 2019.release.xcconfig"; sourceTree = "<group>"; };
@@ -325,6 +331,8 @@
 				363E6AF321FD536A00EBC698 /* TagContent.swift */,
 				B977F305220204550048A02E /* Floor.swift */,
 				6F7639162205614B0028EA21 /* Announcement.swift */,
+				6F76391E2206CF4A0028EA21 /* AnnouncementRepository.swift */,
+				6F76392222072CE20028EA21 /* ApiHandleRepository.swift */,
 			);
 			path = data;
 			sourceTree = "<group>";
@@ -410,6 +418,7 @@
 				6F76391422044CDA0028EA21 /* AnnouncementsViewController.swift */,
 				6F76391822056A860028EA21 /* AnnouncementTableViewCell.swift */,
 				6F76391A220577E10028EA21 /* AnnouncementDataSource.swift */,
+				6F7639202206CFBE0028EA21 /* AnnouncementsViewModel.swift */,
 			);
 			path = Announcement;
 			sourceTree = "<group>";
@@ -778,8 +787,10 @@
 			files = (
 				366B060B21F7604500C912AD /* UICollectionView+Extension.swift in Sources */,
 				3672C2D921F70AC100ACB910 /* SessionTableViewCell.swift in Sources */,
+				6F76391F2206CF4A0028EA21 /* AnnouncementRepository.swift in Sources */,
 				363E6AF621FD545B00EBC698 /* Session+Extension.swift in Sources */,
 				366B060921F756CB00C912AD /* TagsCollectionViewCell.swift in Sources */,
+				6F7639212206CFBE0028EA21 /* AnnouncementsViewModel.swift in Sources */,
 				3672C2C921F5E08C00ACB910 /* UIColor+Extension.swift in Sources */,
 				3672C2DF21F73A9400ACB910 /* SpeakerCell.swift in Sources */,
 				360744F721FAF152003569D3 /* SessionDetailTagsTableViewCell.swift in Sources */,
@@ -797,6 +808,7 @@
 				3672C2D121F6033200ACB910 /* NibLoadable.swift in Sources */,
 				3672C2CD21F6024B00ACB910 /* Reusable.swift in Sources */,
 				43DC80C12200A0F600A3F710 /* FavoriteRepository.swift in Sources */,
+				6F76392322072CE20028EA21 /* ApiHandleRepository.swift in Sources */,
 				B977F3042202041F0048A02E /* FloorMapContentViewController.swift in Sources */,
 				B977F306220204550048A02E /* Floor.swift in Sources */,
 				366B060E21F7652D00C912AD /* PaddingLabel.swift in Sources */,

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
@@ -12,7 +12,7 @@ import RxSwift
 import ioscombined
 
 final class AnnouncementDataSource: NSObject, UITableViewDataSource {
-    typealias Element = [Announcement]
+    typealias Element = [AnnouncementResponse]
     var items: Element = []
     
     private var cellHeightsCache = [IndexPath: CGFloat]()
@@ -34,7 +34,7 @@ final class AnnouncementDataSource: NSObject, UITableViewDataSource {
 }
 
 extension AnnouncementDataSource: RxTableViewDataSourceType {
-    public func tableView(_ tableView: UITableView, observedEvent: Event<[Announcement]>) {
+    public func tableView(_ tableView: UITableView, observedEvent: Event<[AnnouncementResponse]>) {
         Binder(self) { dataSource, element in
             dataSource.items = element
             tableView.reloadData()

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
@@ -15,8 +15,6 @@ final class AnnouncementDataSource: NSObject, UITableViewDataSource {
     typealias Element = [AnnouncementResponse]
     var items: Element = []
     
-    private var cellHeightsCache = [IndexPath: CGFloat]()
-    
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
@@ -48,16 +46,12 @@ extension AnnouncementDataSource: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
     }
-    
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cellHeightsCache[indexPath] = cell.frame.height
-    }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return cellHeightsCache[indexPath] ?? UITableView.automaticDimension
+        return UITableView.automaticDimension
     }
 }

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementDataSource.swift
@@ -33,15 +33,15 @@ final class AnnouncementDataSource: NSObject, UITableViewDataSource {
     }
 }
 
-//extension AnnouncementDataSource: RxTableViewDataSourceType {
-//    public func tableView(_ tableView: UITableView, observedEvent: Event<[Announcement]>) {
-//        Binder(self) { dataSource, element in
-//            dataSource.items = element
-//            tableView.reloadData()
-//            }
-//            .on(observedEvent)
-//    }
-//}
+extension AnnouncementDataSource: RxTableViewDataSourceType {
+    public func tableView(_ tableView: UITableView, observedEvent: Event<[Announcement]>) {
+        Binder(self) { dataSource, element in
+            dataSource.items = element
+            tableView.reloadData()
+            }
+            .on(observedEvent)
+    }
+}
 
 extension AnnouncementDataSource: UITableViewDelegate {
 

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 import ioscombined
 
-class AnnouncementTableViewCell: UITableViewCell, Reusable {
+class AnnouncementTableViewCell: UITableViewCell {
     @IBOutlet weak var announcementIcon: UIImageView!
     @IBOutlet weak var publishedAt: UILabel!
     @IBOutlet weak var title: UILabel!

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
@@ -15,12 +15,9 @@ class AnnouncementTableViewCell: UITableViewCell, Reusable {
     
     var announcement: Announcement? {
         didSet {
-            guard let announcement = announcement else
-                { return }
-            let formatter = DateFormatter()
-            formatter.timeStyle = .short
-            formatter.dateStyle = .short
-            publishedAt.text = formatter.string(from: announcement.publishedAt)
+            guard let announcement = announcement else {
+                return }
+            publishedAt.text = announcement.publishedAt
             announcementIcon.image = announcement.type.iconImage
             title.text = announcement.title
             content.text = announcement.content

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementTableViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import ioscombined
 
 class AnnouncementTableViewCell: UITableViewCell, Reusable {
     @IBOutlet weak var announcementIcon: UIImageView!
@@ -13,14 +14,27 @@ class AnnouncementTableViewCell: UITableViewCell, Reusable {
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var content: UILabel!
     
-    var announcement: Announcement? {
+    var announcement: AnnouncementResponse? {
         didSet {
             guard let announcement = announcement else {
                 return }
             publishedAt.text = announcement.publishedAt
-            announcementIcon.image = announcement.type.iconImage
+            announcementIcon.image = getIconImage(announcementType: announcement.type)
             title.text = announcement.title
             content.text = announcement.content
+        }
+    }
+    
+    func getIconImage(announcementType: String) -> UIImage{
+        switch announcementType {
+        case "notification":
+            return #imageLiteral(resourceName: "annnoucement")
+        case "alert":
+            return #imageLiteral(resourceName: "alert")
+        case "feedback":
+            return #imageLiteral(resourceName: "feedback")
+        default:
+            return #imageLiteral(resourceName: "annnoucement")
         }
     }
 }

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementsViewModel.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementsViewModel.swift
@@ -23,7 +23,7 @@ extension AnnouncementsViewModel {
     }
 
     struct Output {
-        let announcements: Driver<[Announcement]>
+        let announcements: Driver<[AnnouncementResponse]>
         let error: Driver<String?>
     }
 
@@ -40,12 +40,7 @@ extension AnnouncementsViewModel {
         }
         
         let announcements = announcementContents
-            .map { (response: [AnnouncementResponse]) -> [Announcement] in
-                let responseList = response.map({ (announcement: AnnouncementResponse) in
-                    Announcement(title: announcement.title, content: announcement.content, publishedAt: announcement.publishedAt, type: AnnouncementType.getType(announcementType: announcement.type) )
-                })
-                return responseList
-            }.asDriver(onErrorJustReturn: [])
+            .asDriver(onErrorJustReturn: [])
         let error = _error.asDriver()
         return Output(announcements: announcements, error: error)
     }

--- a/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementsViewModel.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Announcement/AnnouncementsViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  AnnouncementsViewModel.swift
+//  DroidKaigi 2019
+//
+//  Created by 佐々木美穂 on 2019/02/03.
+//
+
+import Foundation

--- a/frontend/ios/DroidKaigi 2019/data/Announcement.swift
+++ b/frontend/ios/DroidKaigi 2019/data/Announcement.swift
@@ -11,10 +11,10 @@ import class UIKit.UIImage
 struct Announcement {
     let title: String
     let content: String
-    let publishedAt: Date
+    let publishedAt: String
     let type: AnnouncementType
     
-    init(title: String, content: String, publishedAt: Date, type: AnnouncementType) {
+    init(title: String, content: String, publishedAt: String, type: AnnouncementType) {
         self.title = title
         self.content = content
         self.publishedAt = publishedAt
@@ -26,6 +26,19 @@ enum AnnouncementType {
     case notification
     case alert
     case feedback
+    
+    static func getType(announcementType: String) -> AnnouncementType {
+        switch announcementType {
+        case "notification":
+            return AnnouncementType.notification
+        case "alert":
+            return AnnouncementType.alert
+        case "feedback":
+            return AnnouncementType.feedback
+        default:
+            return AnnouncementType.notification
+        }
+    }
 }
 
 extension AnnouncementType {

--- a/frontend/ios/DroidKaigi 2019/data/AnnouncementRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/data/AnnouncementRepository.swift
@@ -6,3 +6,15 @@
 //
 
 import Foundation
+import ioscombined
+import RxSwift
+
+final class AnnouncementRepository {
+    
+    func fetch() -> Single<[AnnouncementResponse]> {
+        return ApiComponentKt.generateDroidKaigiApi()
+        .getAnnouncementsAsync(lang: LangParameter.en)
+        .asSingle([AnnouncementResponse].self)
+        .catchError { throw handledKotlinException($0)}
+    }
+}

--- a/frontend/ios/DroidKaigi 2019/data/AnnouncementRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/data/AnnouncementRepository.swift
@@ -1,0 +1,8 @@
+//
+//  AnnouncementRepository.swift
+//  DroidKaigi 2019
+//
+//  Created by 佐々木美穂 on 2019/02/03.
+//
+
+import Foundation

--- a/frontend/ios/DroidKaigi 2019/data/ApiHandleRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/data/ApiHandleRepository.swift
@@ -1,0 +1,8 @@
+//
+//  ApiHandleRepository.swift
+//  DroidKaigi 2019
+//
+//  Created by 佐々木美穂 on 2019/02/03.
+//
+
+import Foundation

--- a/frontend/ios/DroidKaigi 2019/data/ApiHandleRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/data/ApiHandleRepository.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+import ioscombined
+
+//FIXME: If you have a more better idea, we can refine this.
+func handledKotlinException(_ error: Error) -> Error {
+    
+    guard let cause = error as? KotlinThrowable else {
+        fatalError("Unexpedeted Error: \(error)")
+    }
+    
+    // Obtain `NSError` from Ktor `IosHttpRequestException`.
+    // See also: data/api/ThrowableExt.kt
+    if let origin = cause.originNSError {
+        return origin
+    }
+    
+    // Return handled kotlin exception.
+    if let handledException = cause as? KotlinException {
+        return handledException
+    }
+    
+    fatalError("Unexpedeted KotlinThrowable: \(cause)")
+}

--- a/frontend/ios/DroidKaigi 2019/data/SessionRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/data/SessionRepository.swift
@@ -21,24 +21,3 @@ final class SessionRepository {
     }
 
 }
-
-//FIXME: If you have a more better idea, we can refine this.
-private func handledKotlinException(_ error: Error) -> Error {
-
-    guard let cause = error as? KotlinThrowable else {
-        fatalError("Unexpedeted Error: \(error)")
-    }
-
-    // Obtain `NSError` from Ktor `IosHttpRequestException`.
-    // See also: data/api/ThrowableExt.kt
-    if let origin = cause.originNSError {
-        return origin
-    }
-
-    // Return handled kotlin exception.
-    if let handledException = cause as? KotlinException {
-        return handledException
-    }
-
-    fatalError("Unexpedeted KotlinThrowable: \(cause)")
-}


### PR DESCRIPTION
## Issue
- close (#708)[https://github.com/DroidKaigi/conference-app-2019/issues/708]

## Overview (Required)
- This pr implements
  - functions of calling announcement api in DroidKaigiApi.kt
  - add AnnouncementRepository to call announcement api
  - add AnnouncementViewModel to make api data usable in AnnouncementViewController
  - make viewcontroller use data obtained from announcement api

From the comments followed pr, I changed
  - replaced Announcement class with AnnouncementResponse which is defined in ioscombined

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
